### PR TITLE
Add an explicit width to the page URL

### DIFF
--- a/frontend/src/features/content-sharing/ui/pages/annotation-details/index.tsx
+++ b/frontend/src/features/content-sharing/ui/pages/annotation-details/index.tsx
@@ -312,6 +312,7 @@ const AnnotationPageTitle = styled.div`
 const AnnotationPageUrl = styled.div`
   font-family: ${(props) => props.theme.fonts.primary};
   color: ${(props) => props.theme.colors.primary};
+  width: 355px;
   font-size: 12px;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
- This rule missing caused the URL CSS truncation not to work, at least on Firefox. Chrome seemed to be fine with it.
- Example (try in FF): https://memex.social/a/0isRyKVnJBqTnFNFadfO
- This is the exact width the element gets in Chrome, so nothing changes on that side.