### PR TITLE
Potential fix to input selection via stateful component

### DIFF
--- a/frontend/src/common-ui/components/text-input.tsx
+++ b/frontend/src/common-ui/components/text-input.tsx
@@ -10,21 +10,56 @@ const StyledInput = styled.input`
   padding: 10px;
 `;
 
-export default function TextInput(
-  props: InputHTMLAttributes<HTMLInputElement> & {
-    onConfirm?(): void;
-  }
-) {
-  return (
-    <StyledInput
-      type="text"
-      {...props}
-      onKeyDown={(event) => {
-        if (props.onConfirm && event.keyCode === 13) {
-          return props.onConfirm();
+interface State {
+    value: string
+    prevValue: string
+}
+
+interface Props {
+    onConfirm: () => void
+    value?: string
+}
+
+export default class TextInput extends React.PureComponent<InputHTMLAttributes<HTMLInputElement> & Props,State> {
+
+    state = {prevValue: "", value:""}
+
+    constructor(props:Props) {
+        super(props);
+        this.state.value = props?.value ?? "";
+        this.state.prevValue = props?.value ?? "";
+    }
+
+    static getDerivedStateFromProps(props: Props, state: State) {
+        if (state.value !== state.prevValue) {
+            return {value: state.value}
         }
-        props.onKeyDown?.(event);
-      }}
-    />
-  );
+
+        if (props?.value && props?.value !== state.value) {
+            return { value: props.value };
+        }
+    }
+
+    handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        this.setState({prevValue: this.state.value, value:e.target.value})
+        this.props?.onChange?.(e)
+    }
+
+    render() {
+        const {onConfirm, value, ...props} = this.props;
+        return (
+            <StyledInput
+                type="text"
+                {...props}
+                onChange={this.handleChange}
+                value={this.state.value}
+                onKeyDown={(event) => {
+                    if (onConfirm && event.keyCode === 13) {
+                        return onConfirm();
+                    }
+                    this.props.onKeyDown?.(event);
+                }}
+            />
+        );
+    }
 }

--- a/frontend/src/features/user-management/ui/components/profile-setup-form.tsx
+++ b/frontend/src/features/user-management/ui/components/profile-setup-form.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {ChangeEvent} from "react";
 import styled from "styled-components";
 import TextInput from "../../../../common-ui/components/text-input";
 import Button from "../../../../common-ui/components/button";
@@ -16,50 +16,73 @@ const DisplayName = styled.div`
   text-align: center;
 `;
 
-export default function ProfileSetupForm(props: {
+interface Props {
   displayName: string;
   onDisplayNameChange(value: string): void;
   onConfirm(): void;
-}) {
-  const placeholder = "John Doe";
-  return (
-    <StyledProfileSetupForm>
-      <Margin bottom="medium">
-        <Header>Set up your display name</Header>
-      </Margin>
-      <Margin bottom="medium">
-        <DisplayName>
-          <TextInput
-            placeholder={placeholder}
-            value={props.displayName}
-            onChange={(e) => props.onDisplayNameChange(e.target.value)}
-            onConfirm={props.onConfirm}
-          />
-        </DisplayName>
-      </Margin>
-      <Margin bottom="small">
-        <Header>Example</Header>
-      </Margin>
-      <Margin bottom="small">
-        <AnnotationReply
-          user={{
-            displayName:
-              props.displayName?.length > 0 ? props.displayName : placeholder,
-          }}
-          reply={{
-            content:
-              "This is what a reply to someone's note looks like with your name attached",
-            createdWhen: Date.now(),
-            normalizedPageUrl: "something",
-          }}
-        />
-      </Margin>
-      <Button
-        type="primary-action"
-        onClick={props.displayName.length ? props.onConfirm : undefined}
-      >
-        Confirm
-      </Button>
-    </StyledProfileSetupForm>
-  );
+}
+
+interface State {
+  displayName: string;
+}
+
+export default class ProfileSetupForm extends React.Component<Props,State> {
+
+    state = {displayName: ""}
+
+    constructor(props:Props) {
+        super(props);
+        this.state.displayName = props.displayName;
+
+    }
+
+    onDisplayNameChange = (e: ChangeEvent<HTMLInputElement>) => {
+        this.setState({displayName:e.target.value})
+        this.props.onDisplayNameChange(e.target.value)
+    }
+
+  render() {
+    const placeholder = "John Doe";
+
+    return (
+        <StyledProfileSetupForm>
+          <Margin bottom="medium">
+            <Header>Set up your display name</Header>
+          </Margin>
+          <Margin bottom="medium">
+            <DisplayName>
+              <TextInput
+                  placeholder={placeholder}
+                  value={this.state.displayName}
+                  onChange={(e) => this.onDisplayNameChange(e)}
+                  onConfirm={this.props.onConfirm}
+              />
+            </DisplayName>
+          </Margin>
+          <Margin bottom="small">
+            <Header>Example</Header>
+          </Margin>
+          <Margin bottom="small">
+            <AnnotationReply
+                user={{
+                  displayName:
+                      this.props.displayName?.length > 0 ? this.props.displayName : placeholder,
+                }}
+                reply={{
+                  content:
+                      "This is what a reply to someone's note looks like with your name attached",
+                  createdWhen: Date.now(),
+                  normalizedPageUrl: "something",
+                }}
+            />
+          </Margin>
+          <Button
+              type="primary-action"
+              onClick={this.props.displayName.length ? this.props.onConfirm : undefined}
+          >
+            Confirm
+          </Button>
+        </StyledProfileSetupForm>
+    );
+  }
 }

--- a/frontend/src/features/user-management/ui/components/profile-setup-form.tsx
+++ b/frontend/src/features/user-management/ui/components/profile-setup-form.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent} from "react";
+import React from "react";
 import styled from "styled-components";
 import TextInput from "../../../../common-ui/components/text-input";
 import Button from "../../../../common-ui/components/button";
@@ -16,73 +16,50 @@ const DisplayName = styled.div`
   text-align: center;
 `;
 
-interface Props {
+export default function ProfileSetupForm(props: {
   displayName: string;
   onDisplayNameChange(value: string): void;
   onConfirm(): void;
-}
-
-interface State {
-  displayName: string;
-}
-
-export default class ProfileSetupForm extends React.Component<Props,State> {
-
-    state = {displayName: ""}
-
-    constructor(props:Props) {
-        super(props);
-        this.state.displayName = props.displayName;
-
-    }
-
-    onDisplayNameChange = (e: ChangeEvent<HTMLInputElement>) => {
-        this.setState({displayName:e.target.value})
-        this.props.onDisplayNameChange(e.target.value)
-    }
-
-  render() {
-    const placeholder = "John Doe";
-
-    return (
-        <StyledProfileSetupForm>
-          <Margin bottom="medium">
-            <Header>Set up your display name</Header>
-          </Margin>
-          <Margin bottom="medium">
-            <DisplayName>
-              <TextInput
-                  placeholder={placeholder}
-                  value={this.state.displayName}
-                  onChange={(e) => this.onDisplayNameChange(e)}
-                  onConfirm={this.props.onConfirm}
-              />
-            </DisplayName>
-          </Margin>
-          <Margin bottom="small">
-            <Header>Example</Header>
-          </Margin>
-          <Margin bottom="small">
-            <AnnotationReply
-                user={{
-                  displayName:
-                      this.props.displayName?.length > 0 ? this.props.displayName : placeholder,
-                }}
-                reply={{
-                  content:
-                      "This is what a reply to someone's note looks like with your name attached",
-                  createdWhen: Date.now(),
-                  normalizedPageUrl: "something",
-                }}
-            />
-          </Margin>
-          <Button
-              type="primary-action"
-              onClick={this.props.displayName.length ? this.props.onConfirm : undefined}
-          >
-            Confirm
-          </Button>
-        </StyledProfileSetupForm>
-    );
-  }
+}) {
+  const placeholder = "John Doe";
+  return (
+    <StyledProfileSetupForm>
+      <Margin bottom="medium">
+        <Header>Set up your display name</Header>
+      </Margin>
+      <Margin bottom="medium">
+        <DisplayName>
+          <TextInput
+            placeholder={placeholder}
+            value={props.displayName}
+            onChange={(e) => props.onDisplayNameChange(e.target.value)}
+            onConfirm={props.onConfirm}
+          />
+        </DisplayName>
+      </Margin>
+      <Margin bottom="small">
+        <Header>Example</Header>
+      </Margin>
+      <Margin bottom="small">
+        <AnnotationReply
+          user={{
+            displayName:
+              props.displayName?.length > 0 ? props.displayName : placeholder,
+          }}
+          reply={{
+            content:
+              "This is what a reply to someone's note looks like with your name attached",
+            createdWhen: Date.now(),
+            normalizedPageUrl: "something",
+          }}
+        />
+      </Margin>
+      <Button
+        type="primary-action"
+        onClick={props.displayName.length ? props.onConfirm : undefined}
+      >
+        Confirm
+      </Button>
+    </StyledProfileSetupForm>
+  );
 }


### PR DESCRIPTION
I had a quick look at the reported bug when using `TextInput` where writing text in the middle of a controlled component would reset the selection to the end.

I observed in the default case of a standard statefull component this issue was not present. The React issue mention keeping the update to within the components onChange.

So that's what I did here - swapping on the functional component and props update for a stateful component. The bug went away after doing that. 
l
Seems to make some sense to me that React will re-render the input in the functional case and therefore loose the selection, I tried adding a ref to aide it's reconciliation but the same issue appeared.

So not sure how it's best to generalise this solution, and also can't explain precisely why this satefull component manages to keep the auxiliary input state where as the functional component doesn't, but it doesn't seem totally unexpected, react probably has some extra references to work with.

Perhaps it's possible to create a statefull, controlled, TextInput as the generic component to alleviate the need to do this for every usage.

Thoughts @ShishKabab ?