### PR TITLE
Text styling for more readable annotations

### DIFF
--- a/frontend/src/features/annotations/ui/components/annotation-box.tsx
+++ b/frontend/src/features/annotations/ui/components/annotation-box.tsx
@@ -19,10 +19,12 @@ const StyledAnnotationBox = styled.div`
 const AnnotationBody = styled.span`
   background-color: ${(props) => props.theme.colors.secondary};
   white-space: normal;
-  padding: 0 5px;
+  padding: 2px 5px;
   box-decoration-break: clone;
-  font-size: 14px;
+  font-size: 18px;
+  line-height: 20px; 
   color: ${(props) => props.theme.colors.primary};
+  font-family: ${(props) => props.theme.fonts.content};
 `;
 
 const AnnotationComment = styled.div`

--- a/frontend/src/main-ui/styles/theme.ts
+++ b/frontend/src/main-ui/styles/theme.ts
@@ -25,6 +25,7 @@ export const theme: Theme = {
   fonts: {
     primary: '"Poppins", sans-serif',
     secondary: '"Poppins", sans-serif',
+    content: 'serif',
   },
   hoverBackgrounds: {
     primary: '#e0e0e0',


### PR DESCRIPTION
Here's a little suggestion to make the external content more readable by increasing the font size, line height and padding. 

I've also made it a Serif font to distinguish it from application content, feels to me a more 'readerly' look. We might want to choose a nice specific Serif font pairing rather than use a generic one, but there's lots more little tweaks yet to come I feel to make the reading experience a bit better (spacing and sizes), here's a little start since I wasn't happy with the default look when sharing.

Here's the look before:
![Screenshot from 2021-01-16 17-04-36](https://user-images.githubusercontent.com/3830518/104816850-00c36280-581e-11eb-9589-18e9a30cd766.png)

And after:
![Screenshot from 2021-01-16 16-50-37](https://user-images.githubusercontent.com/3830518/104816864-16d12300-581e-11eb-8ec7-0b60501793a3.png)

Looks good? @blackforestboi @ShishKabab 