### PR TITLE
Feature/load entry annotations

### DIFF
--- a/frontend/src/common-ui/layouts/default-page-layout.tsx
+++ b/frontend/src/common-ui/layouts/default-page-layout.tsx
@@ -265,7 +265,7 @@ export default function DefaultPageLayout(props: {
   const renderFeedArea = () => {
     if (!isAuthenticated) {
       return (
-        <FeedArea horizontal="medium">
+        <FeedArea>
           <FeedLabel
             onClick={async () => {
               const { result } = await props.services.auth.requestAuth();
@@ -339,7 +339,7 @@ export default function DefaultPageLayout(props: {
         </HeaderAuthArea>
       </StyledHeader>
       <PageMiddleArea viewportWidth={viewportWidth}>
-        <PageMiddleAreaTopBox top="larger" viewportWidth={viewportWidth}>
+        <PageMiddleAreaTopBox top="larger" bottom="medium" viewportWidth={viewportWidth}>
           <PageMidleAreaTitles>
           {props.headerTitle && (
             <HeaderTitle

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/index.tsx
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/index.tsx
@@ -39,7 +39,6 @@ const LoadMoreLink = styled(RouteLink)`
   justify-content: center;
   font-family: ${(props) => props.theme.fonts.primary};
   color: ${(props) => props.theme.colors.primary};
-  background: white;
   font-size: 11px;
   cursor: pointer;
   border-radius: 3px;
@@ -59,7 +58,6 @@ const CollectionLink = styled(RouteLink)`
   justify-content: center;
   font-family: ${(props) => props.theme.fonts.primary};
   color: ${(props) => props.theme.colors.primary};
-  background: white;
   padding-left: 5px;
   cursor: pointer;
   align-items: center;
@@ -112,8 +110,8 @@ const LastSeenLineBackground = styled.div`
 const LastSeenLineLabel = styled.div`
   font-family: ${(props) => props.theme.fonts.primary};
   text-align: center;
-  background: white;
   padding: 0 20px;
+  background: #f6f8fB;
   z-index: 2;
 `;
 
@@ -121,7 +119,6 @@ const LoadMoreReplies = styled.div`
   display: flex;
   justify-content: center;
   font-family: ${(props) => props.theme.fonts.primary};
-  background: white;
   font-size: 11px;
   cursor: pointer;
   border-radius: 3px;

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/index.tsx
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/index.tsx
@@ -415,6 +415,7 @@ export default class HomeFeedPage extends UIElement<
                       onClick: () => this.processEvent('toggleListEntryActivityAnnotations', {
                         listReference: listItem.listReference,
                         listEntryReference: entry.reference,
+                        groupId: listItem.groupId,
                       }),
                     }
                   ] : []}

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/logic.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/logic.ts
@@ -121,7 +121,9 @@ export default class HomeFeedLogic extends UILogic<HomeFeedState, HomeFeedEvent>
                 hasEarlierReplies: i !== 0,
                 replies: repliesByAnnotation[a.reference.id],
             }))
+
             const annotationsData: ActivityData['annotations'] = {}
+            const repliesData: ActivityData['replies'] = {}
 
             for (const annotation of annotations) {
                 annotationsData[annotation.reference.id] = {
@@ -131,7 +133,27 @@ export default class HomeFeedLogic extends UILogic<HomeFeedState, HomeFeedEvent>
                 }
             }
 
+            for (const replies of Object.values(repliesByAnnotation)) {
+                for (const reply of replies) {
+                    repliesData[event.groupId] = {
+                        ...(repliesData[event.groupId] ?? {}),
+                        [reply.reference.id]: {
+                            creatorReference: reply.userReference,
+                            reference: reply.reference,
+                            reply: {
+                                content: reply.reply.content,
+                                createdWhen: reply.reply.createdWhen,
+                                normalizedPageUrl: reply.reply.normalizedPageUrl,
+                            },
+                        }
+                    }
+                }
+            }
+
+            // TODO: figure out what's missing here to cause the replies not to be rendered (pretty sure it's the conversation state)
+
             this.emitMutation({
+                replies: { $merge: repliesData },
                 annotations: { $merge: annotationsData },
                 activityItems: {
                     items: {

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/logic.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/logic.ts
@@ -150,11 +150,27 @@ export default class HomeFeedLogic extends UILogic<HomeFeedState, HomeFeedEvent>
                 }
             }
 
-            // TODO: figure out what's missing here to cause the replies not to be rendered (pretty sure it's the conversation state)
+            const conversationsData: HomeFeedState['conversations'] = {
+                [event.groupId]: {
+                    loadState: 'pristine',
+                    expanded: true,
+                    newReply: {
+                        content: '',
+                        editing: false,
+                        saveState: 'pristine',
+                    },
+                    replies: await Promise.all(Object.values(repliesData[event.groupId]).map(async reply => ({
+                        reference: reply.reference,
+                        reply: reply.reply,
+                        user: await this.users.loadUser(reply.creatorReference),
+                    }))),
+                }
+            }
 
             this.emitMutation({
                 replies: { $merge: repliesData },
                 annotations: { $merge: annotationsData },
+                conversations: { $merge: conversationsData },
                 activityItems: {
                     items: {
                         [event.listReference.id]: {

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/logic.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/logic.ts
@@ -161,7 +161,7 @@ export default class HomeFeedLogic extends UILogic<HomeFeedState, HomeFeedEvent>
             const conversationsData: HomeFeedState['conversations'] = {
                 [event.groupId]: {
                     loadState: 'pristine',
-                    expanded: true,
+                    expanded: false,
                     newReply: {
                         content: '',
                         editing: false,

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
@@ -32,6 +32,7 @@ export type HomeFeedEvent = UIEvent<AnnotationConversationEvent & {
         annotationReference: SharedAnnotationReference
     }
     toggleListEntryActivityAnnotations: {
+        groupId: string
         listReference: SharedListReference
         listEntryReference: SharedListEntryReference
     }

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
@@ -17,9 +17,9 @@ export interface HomeFeedDependencies {
 export type HomeFeedState = {
     loadState: UITaskState
     activityItems: OrderedMap<ActivityItem>
+    replies: ActivityData['replies']
     pageInfo: ActivityData['pageInfo']
     annotations: ActivityData['annotations']
-    replies: ActivityData['replies']
     users: { [userId: string]: Pick<User, 'displayName'> | null }
     lastSeenTimestamp?: number | null
     moreRepliesLoadStates: { [groupId: string]: UITaskState }
@@ -67,7 +67,7 @@ export interface ListEntryActivityItem {
     hasAnnotations?: boolean
     areAnnotationsShown?: boolean
     annotationsLoadState: UITaskState
-    annotations: SharedAnnotationReference[]
+    annotations: OrderedMap<AnnotationActivityItem>
 }
 
 export interface PageActivityItem extends TopLevelActivityItem {

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
@@ -59,6 +59,7 @@ export interface ListActivityItem extends TopLevelActivityItem {
 export interface ListEntryActivityItem {
     type: 'list-entry-item',
     reference: SharedListEntryReference
+    creator: UserReference
     entryTitle: string
     originalUrl: string
     normalizedPageUrl: string

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
@@ -31,6 +31,10 @@ export type HomeFeedEvent = UIEvent<AnnotationConversationEvent & {
         groupId: string
         annotationReference: SharedAnnotationReference
     }
+    loadListEntryActivityAnnotations: {
+        listReference: SharedListReference
+        listEntryReference: SharedListEntryReference
+    }
 }>
 
 export type HomeFeedSignal = UISignal<
@@ -58,8 +62,11 @@ export interface ListEntryActivityItem {
     entryTitle: string
     originalUrl: string
     normalizedPageUrl: string
-    hasAnnotations?: boolean
     activityTimestamp: number
+    hasAnnotations?: boolean
+    areAnnotationsShown?: boolean
+    annotationsLoadState: UITaskState
+    annotations: SharedAnnotationReference[]
 }
 
 export interface PageActivityItem extends TopLevelActivityItem {

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
@@ -31,7 +31,7 @@ export type HomeFeedEvent = UIEvent<AnnotationConversationEvent & {
         groupId: string
         annotationReference: SharedAnnotationReference
     }
-    loadListEntryActivityAnnotations: {
+    toggleListEntryActivityAnnotations: {
         listReference: SharedListReference
         listEntryReference: SharedListEntryReference
     }

--- a/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
+++ b/frontend/src/features/activity-streams/ui/pages/home-feed/types.ts
@@ -1,4 +1,4 @@
-import { SharedAnnotationReference, SharedPageInfo, SharedAnnotation, SharedListReference } from "@worldbrain/memex-common/lib/content-sharing/types";
+import { SharedAnnotationReference, SharedPageInfo, SharedAnnotation, SharedListReference, SharedListEntryReference } from "@worldbrain/memex-common/lib/content-sharing/types";
 import { ConversationReplyReference, ConversationReply } from "@worldbrain/memex-common/lib/content-conversations/types";
 import { UserReference, User } from "@worldbrain/memex-common/lib/web-interface/types/users";
 import { UIEvent, UISignal } from "../../../../../main-ui/classes/logic";
@@ -6,6 +6,7 @@ import { UIElementServices } from "../../../../../main-ui/classes";
 import { AnnotationConversationEvent, AnnotationConversationsState } from "../../../../content-conversations/ui/types";
 import { StorageModules } from "../../../../../storage/types";
 import { UITaskState } from "../../../../../main-ui/types";
+import { OrderedMap } from "../../../../../utils/ordered-map";
 
 export interface HomeFeedDependencies {
     services: UIElementServices<'contentConversations' | 'auth' | 'overlay' | 'activityStreams' | 'router'>;
@@ -15,7 +16,7 @@ export interface HomeFeedDependencies {
 
 export type HomeFeedState = {
     loadState: UITaskState
-    activityItems: Array<ActivityItem>
+    activityItems: OrderedMap<ActivityItem>
     pageInfo: ActivityData['pageInfo']
     annotations: ActivityData['annotations']
     replies: ActivityData['replies']
@@ -48,12 +49,12 @@ export interface ListActivityItem extends TopLevelActivityItem {
     reason: 'pages-added-to-list'
     listName: string
     listReference: SharedListReference
-    entries: Array<ListEntryActivityItem>
+    entries: OrderedMap<ListEntryActivityItem>
 }
 
-// TODO: Maybe just replace this with `PageActivityItem`...
 export interface ListEntryActivityItem {
     type: 'list-entry-item',
+    reference: SharedListEntryReference
     entryTitle: string
     originalUrl: string
     normalizedPageUrl: string
@@ -65,7 +66,7 @@ export interface PageActivityItem extends TopLevelActivityItem {
     type: 'page-item'
     reason: 'new-replies'
     normalizedPageUrl: string
-    annotations: Array<AnnotationActivityItem>
+    annotations: OrderedMap<AnnotationActivityItem>
 }
 
 export interface AnnotationActivityItem {

--- a/frontend/src/features/annotations/ui/components/annotations-in-page.tsx
+++ b/frontend/src/features/annotations/ui/components/annotations-in-page.tsx
@@ -18,7 +18,7 @@ import NewAnnotationReply, {
 import { SharedAnnotationInPage } from "./types";
 import { ConversationReplyReference } from "@worldbrain/memex-common/lib/content-conversations/types";
 
-const AnnotationContainer = styled.div`
+const AnnotationContainer = styled(Margin)`
   display: flex;
   justify-content: center;
 `;
@@ -27,7 +27,7 @@ const AnnotationLine = styled.span`
   height: auto;
   width: 4px;
   background: #e0e0e0;
-  margin: -8px 10px 4px;
+  margin: -8px 10px 15px;
 `;
 
 const AnnotationReplyContainer = styled.div`
@@ -80,7 +80,7 @@ export default function AnnotationsInPage(
 ) {
   if (props.loadState === "pristine" || props.loadState === "running") {
     return (
-      <AnnotationContainer>
+      <AnnotationContainer bottom="large">
         <AnnotationLine />
         <AnnotationList>
           <CenteredContent>
@@ -129,7 +129,7 @@ export default function AnnotationsInPage(
   };
 
   return (
-    <AnnotationContainer>
+    <AnnotationContainer bottom="large">
       <AnnotationLine />
       <AnnotationList>
         {props.annotations.map(

--- a/frontend/src/features/annotations/ui/components/annotations-in-page.tsx
+++ b/frontend/src/features/annotations/ui/components/annotations-in-page.tsx
@@ -52,7 +52,7 @@ const CenteredContent = styled.div`
 export default function AnnotationsInPage(
   props: {
     loadState: UITaskState;
-    annotations?: Array<SharedAnnotationInPage> | null;
+    annotations?: Array<SharedAnnotationInPage | null> | null;
     annotationConversations?: AnnotationConversationStates | null;
     getAnnotationConversation?: (
       annotationReference: SharedAnnotationReference

--- a/frontend/src/features/content-sharing/ui/pages/collection-details/index.tsx
+++ b/frontend/src/features/content-sharing/ui/pages/collection-details/index.tsx
@@ -98,7 +98,6 @@ const ToggleAllAnnotations = styled.div`
   cursor: pointer;
   font-size: 12px;
   width: fit-content;
-  background-color: #fff;
   padding: 0 5px;
   margin: 5px 0 10px;
   border-radius: 5px;

--- a/frontend/src/features/user-management/ui/containers/auth-header/index.tsx
+++ b/frontend/src/features/user-management/ui/containers/auth-header/index.tsx
@@ -16,6 +16,8 @@ import AccountSettings from "../account-settings-dialog";
 const StyledAuthHeader = styled.div``;
 const LoginAction = styled.div`
   cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
 `;
 const UserInfo = styled.div`
   display: flex;

--- a/frontend/src/main-ui/components/list-sidebar/lists-sidebar.tsx
+++ b/frontend/src/main-ui/components/list-sidebar/lists-sidebar.tsx
@@ -28,7 +28,6 @@ const ListContent = styled.div`
   display: flex;
   flex-direction: column;
   padding-bottom: 100px;
-  padding-left: 5px;
 `
 
 const SectionTitle = styled.div`

--- a/frontend/src/main-ui/components/list-sidebar/lists-sidebar.tsx
+++ b/frontend/src/main-ui/components/list-sidebar/lists-sidebar.tsx
@@ -51,16 +51,19 @@ const ListNameLink = styled(RouteLink)`
   font-weight: 500;
 
   &:hover {
-    background: ${(props) => props.theme.colors.grey};;
+    background: ${(props) => props.theme.colors.grey};
   }
 `;
 
 const EmptyMsg = styled.span`
   font-size: 12px;
+  padding-left: 5px;
 `;
 
 const ErrorMsg = styled.span`
   font-size: 12px;
+  color: ${(props) => props.theme.colors.warning};
+  padding-left: 5px;
 `;
 
 export interface Props {

--- a/frontend/src/scenario-utils/activities.ts
+++ b/frontend/src/scenario-utils/activities.ts
@@ -35,11 +35,6 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
         entity: { type: 'shared-annotation-reference', id: 'third-annotation' },
         feeds: { home: true },
     })
-    await services.activityStreams.followEntity({
-        entityType: 'sharedList',
-        entity: { type: 'shared-list-reference', id: 'default-list' },
-        feeds: { home: true },
-    })
     await storage.serverModules.activityFollows.storeFollow({
         userReference: services.auth.getCurrentUserReference()!,
         collection: 'sharedList',

--- a/frontend/src/scenario-utils/activities.ts
+++ b/frontend/src/scenario-utils/activities.ts
@@ -132,4 +132,12 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
         email: 'default-user',
         password: 'bling'
     })
+
+    await services.contentConversations.submitReply({
+        pageCreatorReference: services.auth.getCurrentUserReference()!,
+        annotationReference: sharedAnnotationReferences['test-annot-1'],
+        normalizedPageUrl: 'new.com/one',
+        isFirstReply: false,
+        reply: { content: 'Another test annot reply - from John Doe!' }
+    })
 }

--- a/frontend/src/scenario-utils/activities.ts
+++ b/frontend/src/scenario-utils/activities.ts
@@ -35,6 +35,11 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
         entity: { type: 'shared-annotation-reference', id: 'third-annotation' },
         feeds: { home: true },
     })
+    await services.activityStreams.followEntity({
+        entityType: 'sharedList',
+        entity: { type: 'shared-list-reference', id: 'default-list' },
+        feeds: { home: true },
+    })
     await storage.serverModules.activityFollows.storeFollow({
         userReference: services.auth.getCurrentUserReference()!,
         collection: 'sharedList',

--- a/frontend/src/scenario-utils/activities.ts
+++ b/frontend/src/scenario-utils/activities.ts
@@ -97,7 +97,15 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
         ],
         userReference: services.auth.getCurrentUserReference()!
     })
-    await storage.serverModules.contentSharing.createAnnotations({
+    await storage.serverModules.contentSharing.createPageInfo({
+        creatorReference: services.auth.getCurrentUserReference()!,
+        pageInfo: {
+            fullTitle: 'New page',
+            normalizedUrl: 'new.com/one',
+            originalUrl: 'https://new.com/one',
+        }
+    })
+    const { sharedAnnotationReferences } = await storage.serverModules.contentSharing.createAnnotations({
         creator: services.auth.getCurrentUserReference()!,
         listReferences: [{ type: 'shared-list-reference', id: 'default-list' }],
         annotationsByPage: {
@@ -105,6 +113,13 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
                 { createdWhen: Date.now(), comment: 'test note', localId: 'test-annot-1' },
             ]
         }
+    })
+    await services.contentConversations.submitReply({
+        pageCreatorReference: services.auth.getCurrentUserReference()!,
+        annotationReference: sharedAnnotationReferences['test-annot-1'],
+        normalizedPageUrl: 'new.com/one',
+        isFirstReply: true,
+        reply: { content: 'Test annot reply' }
     })
     await services.auth.logout()
 

--- a/frontend/src/scenario-utils/activities.ts
+++ b/frontend/src/scenario-utils/activities.ts
@@ -126,6 +126,14 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
         isFirstReply: true,
         reply: { content: 'Test annot reply' }
     })
+
+    await services.contentConversations.submitReply({
+        pageCreatorReference: services.auth.getCurrentUserReference()!,
+        annotationReference: sharedAnnotationReferences['test-annot-1'],
+        normalizedPageUrl: 'new.com/one',
+        isFirstReply: true,
+        reply: { content: 'Another test annot reply' }
+    })
     await services.auth.logout()
 
     await services.auth.loginWithEmailPassword({
@@ -138,6 +146,6 @@ export const setupTestActivities = async ({ services, storage }: { services: Ser
         annotationReference: sharedAnnotationReferences['test-annot-1'],
         normalizedPageUrl: 'new.com/one',
         isFirstReply: false,
-        reply: { content: 'Another test annot reply - from John Doe!' }
+        reply: { content: 'Yet another test reply - from John Doe!' }
     })
 }

--- a/frontend/src/utils/ordered-map.ts
+++ b/frontend/src/utils/ordered-map.ts
@@ -1,0 +1,26 @@
+export interface OrderedMap<T> {
+    items: { [key in string | number]: T }
+    order: Array<string | number>
+}
+
+type KeySelector<T> = (el: T) => string | number
+
+export const createOrderedMap = <T>(): OrderedMap<T> => ({ items: {}, order: [] })
+
+export const arrayToOrderedMap = <T>(arr: T[], getKey: KeySelector<T>): OrderedMap<T> => ({
+    order: arr.map(el => getKey(el)),
+    items: arr.reduce((prev, curr) => ({
+        ...prev,
+        [getKey(curr)]: curr,
+    }), {}),
+})
+
+export const mapOrderedMap = <T, Return>(
+    map: OrderedMap<T>,
+    cb: (el: T, index: number) => Return,
+    inputArrayChainFn: (inputArray: Array<string | number>) => Array<string | number> = a => a
+): Return[] =>
+    inputArrayChainFn(map.order).map((id, i) => cb(map.items[id], i))
+
+export const getOrderedMapIndex = <T>(map: OrderedMap<T>, index: number): T =>
+    map.items[map.order[index]]


### PR DESCRIPTION
This adds support for loading annots, with replies and reply functionality, to the shared list entries - when pressing the comments button

Notion doc: https://www.notion.so/worldbrain/Comment-icon-in-activities-should-unfold-the-comments-for-that-page-not-go-to-the-collection-6634c6412f4443648d291fc92edb943c